### PR TITLE
Optimize backend test speed (fixtures + bcrypt test cost)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,6 +3,7 @@ ENVIRONMENT=development  # development, testing, production
 SECRET_KEY=your-secret-key-min-32-chars
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
+BCRYPT_ROUNDS=12  # use 4 for faster local/CI tests
 
 # Database Configuration
 DATABASE_URL=postgresql://task_user:dev_password@localhost:5432/task_manager

--- a/backend/core/security.py
+++ b/backend/core/security.py
@@ -16,10 +16,14 @@ if not _algorithm:
 SECRET_KEY: str = _secret_key
 ALGORITHM: str = _algorithm
 ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "720"))
+TESTING = os.getenv("TESTING", "").lower() == "true"
+BCRYPT_ROUNDS = int(os.getenv("BCRYPT_ROUNDS", "4" if TESTING else "12"))
 
 
 # Configure bcrypt for password hashing
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+pwd_context = CryptContext(
+    schemes=["bcrypt"], deprecated="auto", bcrypt__rounds=BCRYPT_ROUNDS
+)
 
 
 def hash_password(password: str) -> str:


### PR DESCRIPTION
## Summary
- optimize backend test fixture lifecycle by creating/dropping schema tables once per session
- reset database state per test with `TRUNCATE ... RESTART IDENTITY CASCADE` instead of per-test DDL
- make bcrypt rounds configurable and lower default cost during tests (`TESTING=true` -> `BCRYPT_ROUNDS=4`)
- align test DB fallback URL in `backend/tests/conftest.py` to localhost:5433
- document `BCRYPT_ROUNDS` in `backend/.env.example`

## Verification
- `cd backend && .venv/bin/ruff check routers/ services/ core/ schemas/ main.py db_models.py db_config.py dependencies.py`
- `cd backend && .venv/bin/mypy routers/ services/ core/ schemas/ main.py db_models.py db_config.py dependencies.py`
- `cd backend && .venv/bin/pytest -q`
  - result: `71 passed, 8 warnings in 6.33s`

## Notes
- warnings are existing deprecations and non-blocking for this change
