### PR TITLE
Task #2: frontend environment hardening

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8000

--- a/frontend/docs/ARCHITECTURE.md
+++ b/frontend/docs/ARCHITECTURE.md
@@ -188,3 +188,6 @@ useTasks hook (manages task list state):
 
 ### Environment Variables
 - `VITE_API_URL` — Backend API base URL (set in build env or `.env`)
+- Env access is centralized in `src/config/env.js` (`API_BASE_URL`, `buildApiUrl()`).
+- Local runtime (`vite dev` / localhost) defaults to `http://localhost:8000` when `VITE_API_URL` is not set.
+- Non-local runtime throws at startup if `VITE_API_URL` is missing.

--- a/frontend/docs/PATTERNS.md
+++ b/frontend/docs/PATTERNS.md
@@ -22,6 +22,20 @@ export const taskService = {
 
 ---
 
+## Environment Config
+
+Frontend env access is centralized in `src/config/env.js`:
+
+```javascript
+import { API_BASE_URL, buildApiUrl } from '../config/env';
+```
+
+- `API_BASE_URL` is used by axios clients/services.
+- `buildApiUrl(path)` is used when converting backend-relative asset paths (for example avatar URLs) into absolute URLs.
+- Do not read `import.meta.env.VITE_API_URL` directly in components/services.
+
+---
+
 ## Component Organization
 
 Components are grouped by feature domain under `src/components/`:

--- a/frontend/docs/REVIEW_CHECKLIST.md
+++ b/frontend/docs/REVIEW_CHECKLIST.md
@@ -8,6 +8,7 @@ Run through this checklist after every implementation session, before committing
 
 - [ ] No secrets or API keys in committed code
 - [ ] `VITE_API_URL` used for backend URL (not hardcoded)
+- [ ] Env access goes through `src/config/env.js` (no direct `import.meta.env.VITE_API_URL` reads in runtime code)
 - [ ] User-generated content rendered safely (no `dangerouslySetInnerHTML`)
 - [ ] Auth token cleared on 401 response (handled by axios interceptor)
 - [ ] Permission checks in UI match backend enforcement (don't show buttons for unauthorized actions)

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,9 +1,8 @@
 import axios from 'axios';
-
-const API_URL = import.meta.env.VITE_API_URL || 'http://54.80.178.193:8000';
+import { API_BASE_URL } from './config/env';
 
 const api = axios.create({
-  baseURL: API_URL,
+  baseURL: API_BASE_URL,
 });
 
 // Add token to every request if it exists

--- a/frontend/src/components/Activity/ActivityItem.jsx
+++ b/frontend/src/components/Activity/ActivityItem.jsx
@@ -9,10 +9,7 @@ import {
 function ActivityItem({ activity }) {
   const [showDetails, setShowDetails] = useState(false);
 
-  const { icon, color } = getActivityIcon(
-    activity.action,
-    activity.resource_type
-  );
+  const { icon } = getActivityIcon(activity.action, activity.resource_type);
   const description = formatActivityDescription(activity);
   const timeAgo = formatRelativeTime(activity.created_at);
 

--- a/frontend/src/components/Comments/CommentItem.jsx
+++ b/frontend/src/components/Comments/CommentItem.jsx
@@ -25,15 +25,6 @@ function CommentItem({ comment, onDelete, onUpdate, isTaskOwner }) {
     }
   }, [comment.content, isEditing]);
 
-  const formatDate = (dateString) => {
-    return new Date(dateString).toLocaleString(undefined, {
-      month: 'short',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-    });
-  };
-
   const isCommentAuthor = currentUser && comment.username === currentUser;
   const canEdit = isCommentAuthor;
   const canDelete = isCommentAuthor || isTaskOwner;

--- a/frontend/src/components/Common/UserSearch.jsx
+++ b/frontend/src/components/Common/UserSearch.jsx
@@ -20,7 +20,7 @@ function UserSearch({ onSelect }) {
         const response = await userService.searchUsers(query);
         setResults(response.data);
         setShowResults(true);
-      } catch (err) {
+      } catch {
         toast.error('Search failed');
         setResults([]);
       } finally {

--- a/frontend/src/components/Files/FilesSection.jsx
+++ b/frontend/src/components/Files/FilesSection.jsx
@@ -52,7 +52,7 @@ function FilesSection({ taskId, isExpanded, canUpload, canDelete }) {
         }
       );
       setFiles([...files, response.data]);
-    } catch (err) {
+    } catch {
       toast.error('Upload failed');
     } finally {
       setUploading(false);
@@ -71,7 +71,7 @@ function FilesSection({ taskId, isExpanded, canUpload, canDelete }) {
       link.click();
       link.remove();
       window.URL.revokeObjectURL(url);
-    } catch (err) {
+    } catch {
       toast.error('Download failed');
     }
   };
@@ -86,7 +86,7 @@ function FilesSection({ taskId, isExpanded, canUpload, canDelete }) {
     try {
       await taskService.deleteFile(fileToDelete.id);
       setFiles(files.filter((f) => f.id !== fileToDelete.id));
-    } catch (err) {
+    } catch {
       toast.error('Failed to delete file');
     } finally {
       setFileToDelete(null);

--- a/frontend/src/components/Settings/ProfileSection.jsx
+++ b/frontend/src/components/Settings/ProfileSection.jsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { taskService } from '../../services/taskService';
 import { userService } from '../../services/userService';
 import { authService } from '../../services/authService';
+import { buildApiUrl } from '../../config/env';
 
 function ProfileSection({ user, onUserUpdate, avatarUrl }) {
   const [currentAvatar, setCurrentAvatar] = useState(avatarUrl);
@@ -64,9 +65,7 @@ function ProfileSection({ user, onUserUpdate, avatarUrl }) {
     try {
       setIsUploading(true);
       const response = await userService.updateAvatar(formData);
-      const fullUrl = `${import.meta.env.VITE_API_URL}${
-        response.data.avatar_url
-      }`;
+      const fullUrl = buildApiUrl(response.data.avatar_url);
       const cacheBustedUrl = `${fullUrl}?t=${Date.now()}`;
       setCurrentAvatar(cacheBustedUrl);
       if (onUserUpdate) onUserUpdate();

--- a/frontend/src/components/Sharing/ShareModal.jsx
+++ b/frontend/src/components/Sharing/ShareModal.jsx
@@ -59,7 +59,7 @@ function ShareModal({ taskId, onClose, onCountChange }) {
         prev.filter((s) => s.shared_with_username !== username)
       );
       toast.success(`Removed access for ${username}`);
-    } catch (err) {
+    } catch {
       toast.error('Failed to revoke access');
     }
   };

--- a/frontend/src/components/Tasks/TaskCard.jsx
+++ b/frontend/src/components/Tasks/TaskCard.jsx
@@ -44,6 +44,8 @@ function TaskCard({ task, onToggle, onDelete, onUpdate, isOwner = true }) {
   }, []);
 
   useEffect(() => {
+    // Keep local badge in sync with parent task refreshes.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setShareCount(task.share_count || 0);
   }, [task.share_count]);
 

--- a/frontend/src/components/Tasks/TaskDashboard.jsx
+++ b/frontend/src/components/Tasks/TaskDashboard.jsx
@@ -5,6 +5,7 @@ import { useTasks } from '../../hooks/useTasks';
 import { taskService } from '../../services/taskService';
 import { userService } from '../../services/userService'; // Import userService
 import { THEME } from '../../styles/theme';
+import { buildApiUrl } from '../../config/env';
 import ActivityTimeline from '../Activity/ActivityTimeline';
 import UserMenu from '../Common/UserMenu';
 import SettingsModal from '../Settings/SettingsModal';
@@ -13,7 +14,7 @@ import TaskList from './TaskList';
 
 function TaskDashboard({ onLogout }) {
   const [user, setUser] = useState(null);
-  const [avatarTimestamp, setAvatarTimestamp] = useState(Date.now());
+  const [avatarTimestamp, setAvatarTimestamp] = useState(() => Date.now());
   const [showSettings, setShowSettings] = useState(false);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
@@ -60,10 +61,14 @@ function TaskDashboard({ onLogout }) {
   };
 
   useEffect(() => {
+    // Initial profile load on mount.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchProfile(false);
   }, []);
 
   useEffect(() => {
+    // Reset pagination when filters/view change.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setPage(1);
   }, [filters, view]);
 
@@ -119,7 +124,7 @@ function TaskDashboard({ onLogout }) {
         )
       );
       fetchStats();
-    } catch (err) {
+    } catch {
       toast.error('Failed to update task status');
     }
   };
@@ -130,13 +135,13 @@ function TaskDashboard({ onLogout }) {
       setTasks(tasks.filter((t) => t.id !== taskId));
       fetchStats();
       toast.success('Task deleted');
-    } catch (err) {
+    } catch {
       toast.error('Failed to delete task');
     }
   };
 
   const fullAvatarUrl = user?.avatar_url
-    ? `${import.meta.env.VITE_API_URL}${user.avatar_url}?t=${avatarTimestamp}`
+    ? `${buildApiUrl(user.avatar_url)}?t=${avatarTimestamp}`
     : null;
 
   return (

--- a/frontend/src/config/env.js
+++ b/frontend/src/config/env.js
@@ -1,0 +1,38 @@
+const LOCAL_API_URL = 'http://localhost:8000';
+const rawApiUrl = import.meta.env.VITE_API_URL?.trim();
+const isLocalRuntime =
+  import.meta.env.DEV ||
+  ['localhost', '127.0.0.1', '0.0.0.0'].includes(window.location.hostname);
+
+function normalizeBaseUrl(url) {
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+function resolveApiBaseUrl() {
+  if (rawApiUrl) {
+    return normalizeBaseUrl(rawApiUrl);
+  }
+
+  if (isLocalRuntime) {
+    return LOCAL_API_URL;
+  }
+
+  throw new Error(
+    'Missing VITE_API_URL. Set VITE_API_URL in your frontend environment configuration.'
+  );
+}
+
+export const API_BASE_URL = resolveApiBaseUrl();
+
+export function buildApiUrl(path = '') {
+  if (!path) {
+    return API_BASE_URL;
+  }
+
+  if (path.startsWith('http://') || path.startsWith('https://')) {
+    return path;
+  }
+
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${API_BASE_URL}${normalizedPath}`;
+}

--- a/frontend/src/services/healthService.js
+++ b/frontend/src/services/healthService.js
@@ -1,12 +1,12 @@
 import axios from 'axios';
+import { API_BASE_URL } from '../config/env';
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://54.80.178.193:8000';
 const WARMUP_TIMEOUT_MS = 5000;
 
 export const healthService = {
   warmUpBackend: ({ signal } = {}) =>
     axios.get('/health', {
-      baseURL: API_URL,
+      baseURL: API_BASE_URL,
       signal,
       timeout: WARMUP_TIMEOUT_MS,
       headers: {


### PR DESCRIPTION
Closes #2

## Summary
- remove hardcoded backend URL fallbacks from runtime API path construction
- add centralized env config utility at `frontend/src/config/env.js`
  - reads `VITE_API_URL`
  - defaults to `http://localhost:8000` only for local runtime
  - throws a clear startup error in non-local runtime when `VITE_API_URL` is missing
- switch `src/api.js` and `src/services/healthService.js` to `API_BASE_URL`
- switch avatar URL assembly to `buildApiUrl(...)` in profile/dashboard components
- add `frontend/.env.example`
- update frontend env docs (`ARCHITECTURE.md`, `PATTERNS.md`, `REVIEW_CHECKLIST.md`)

## Verification
- `make frontend-verify`
  - lint: passes (warnings only)
  - build: passes

## Notes
- Included minimal lint-debt cleanups required to make `frontend-verify` pass on this branch.
