### PR TITLE
Task #7: Integrate bandit security scanning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ backend-verify:
 	@cd backend && \
 		ruff check routers/ services/ core/ schemas/ main.py db_models.py db_config.py dependencies.py && \
 		mypy routers/ services/ core/ schemas/ main.py db_models.py db_config.py dependencies.py && \
+		bandit -r routers/ services/ core/ -ll && \
 		pytest -v
 
 frontend-verify:

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -53,11 +53,11 @@ ruff check routers/ services/ core/ schemas/ main.py db_models.py db_config.py d
 # Type check
 mypy routers/ services/ core/ schemas/ main.py db_models.py db_config.py dependencies.py
 
+# Security scan
+bandit -r routers/ services/ core/ -ll
+
 # Run tests
 pytest -v
-
-# Security check (if bandit is installed)
-bandit -r routers/ services/ core/ -ll
 ```
 
 ### Database

--- a/backend/docs/PATTERNS.md
+++ b/backend/docs/PATTERNS.md
@@ -200,6 +200,20 @@ def register(request: Request, ...):
 
 ---
 
+## Security Scanning (Bandit)
+
+Backend verification includes Bandit static security scanning on runtime modules:
+
+```bash
+bandit -r routers/ services/ core/ -ll
+```
+
+`-ll` keeps the gate focused on medium/high severity findings to reduce low-signal false positives in CI.
+
+**Convention:** Run Bandit via `make backend-verify` (or the same command directly) before merge. If a suppression is required, scope it narrowly and document why.
+
+---
+
 ## Test Fixtures
 
 Tests use a real PostgreSQL test database (`task_manager_test`) with the `faros` schema. Key fixtures in `tests/conftest.py`:

--- a/backend/docs/REVIEW_CHECKLIST.md
+++ b/backend/docs/REVIEW_CHECKLIST.md
@@ -21,6 +21,7 @@ Run through this checklist after every implementation session, before committing
 - [ ] Runtime modules use `core.settings.settings` (no new direct `os.getenv()` reads)
 - [ ] CORS origins are explicit (no `*` wildcard)
 - [ ] Rate limiting applied to auth endpoints and creation endpoints
+- [ ] Bandit security scan passes: `cd backend && bandit -r routers/ services/ core/ -ll`
 
 ## Performance
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,3 +22,4 @@ pytest==9.0.1
 pytest-asyncio==1.3.0
 ruff==0.14.6
 mypy==1.18.2
+bandit==1.9.4


### PR DESCRIPTION
## Summary
- add `bandit` to backend development/verification dependencies
- integrate Bandit into `make backend-verify` so repo-level and CI backend gates include security scanning
- document Bandit expectations in backend docs and verification guidance

## Verification
- `PATH="/home/odys/faros-task-manager/backend/.venv/bin:$PATH" make backend-verify`
- `cd backend && .venv/bin/bandit -r routers/ services/ core/ -ll`

## Notes
- Bandit gate uses `-ll` to focus on medium/high severity findings and keep CI noise low.
- Current scan reports one low-severity B105 heuristic (`"bearer"`) below the configured threshold, so it does not fail the gate.

Closes #7
