### PR TITLE
Task #21: align auth and verification branding

### DIFF
--- a/frontend/src/components/Auth/ForgotPasswordForm.jsx
+++ b/frontend/src/components/Auth/ForgotPasswordForm.jsx
@@ -30,7 +30,7 @@ function ForgotPasswordForm({ onSwitchToLogin }) {
       <div className="flex min-h-screen items-center justify-center bg-zinc-950 p-4">
         <div className="w-full max-w-md rounded-2xl border border-zinc-800 bg-zinc-900/80 p-8 text-center shadow-xl animate-in zoom-in duration-300">
           <p className="mb-2 text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-400">
-            Lighthouse Ops
+            FAROS
           </p>
           <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-emerald-900/30">
             <Mail className="text-emerald-400 w-8 h-8" />
@@ -57,7 +57,7 @@ function ForgotPasswordForm({ onSwitchToLogin }) {
     <div className="flex min-h-screen items-center justify-center bg-zinc-950 p-4">
       <div className="w-full max-w-md rounded-2xl border border-zinc-800 bg-zinc-900/80 p-8 shadow-xl animate-in fade-in slide-in-from-bottom-4 duration-500">
         <p className="mb-2 text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-400">
-          Lighthouse Ops
+          FAROS
         </p>
         <button
           onClick={onSwitchToLogin}

--- a/frontend/src/components/Auth/LoginForm.jsx
+++ b/frontend/src/components/Auth/LoginForm.jsx
@@ -25,7 +25,7 @@ function LoginForm({
             </span>
           </div>
           <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-400">
-            Lighthouse Ops
+            FAROS
           </p>
           <h1 className="text-4xl font-black tracking-tight text-emerald-50 mb-2">
             FAROS
@@ -123,9 +123,7 @@ function LoginForm({
         </div>
 
         <div className="mt-10 text-center">
-          <p className="text-zinc-500 text-xs font-mono">
-            © 2025 Faros Manager
-          </p>
+          <p className="text-zinc-500 text-xs font-mono">© 2026 FAROS</p>
         </div>
       </div>
     </div>

--- a/frontend/src/components/Auth/PasswordResetForm.jsx
+++ b/frontend/src/components/Auth/PasswordResetForm.jsx
@@ -85,7 +85,7 @@ function PasswordResetForm({ token, onSwitchToLogin }) {
       <div className="flex min-h-screen items-center justify-center bg-zinc-950 p-4">
         <div className="w-full max-w-md rounded-2xl border border-zinc-800 bg-zinc-900/80 p-8 text-center shadow-xl animate-in zoom-in duration-300">
           <p className="mb-2 text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-400">
-            Lighthouse Ops
+            FAROS
           </p>
           <CheckCircle className="w-16 h-16 text-emerald-500 mx-auto mb-4" />
           <h2 className="text-2xl font-bold text-white mb-2">
@@ -109,7 +109,7 @@ function PasswordResetForm({ token, onSwitchToLogin }) {
     <div className="flex min-h-screen items-center justify-center bg-zinc-950 p-4">
       <div className="w-full max-w-md rounded-2xl border border-zinc-800 bg-zinc-900/80 p-8 shadow-xl animate-in fade-in slide-in-from-bottom-4 duration-500">
         <p className="mb-2 text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-400">
-          Lighthouse Ops
+          FAROS
         </p>
         <div className="flex items-center gap-3 mb-6">
           <div className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-900/30">

--- a/frontend/src/components/Auth/RegisterForm.jsx
+++ b/frontend/src/components/Auth/RegisterForm.jsx
@@ -36,7 +36,7 @@ function RegisterForm({ onRegister, isRegistering, onSwitchToLogin }) {
             </span>
           </div>
           <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-400">
-            Lighthouse Ops
+            FAROS
           </p>
           <h1 className="text-4xl font-black tracking-tight text-white mb-2">
             FAROS

--- a/frontend/src/pages/VerifyEmailPage.jsx
+++ b/frontend/src/pages/VerifyEmailPage.jsx
@@ -41,7 +41,7 @@ function VerifyEmailPage({ token, onComplete }) {
     <div className="flex min-h-screen items-center justify-center bg-zinc-950 p-4 animate-in fade-in duration-500">
       <div className="w-full max-w-md rounded-2xl border border-zinc-800 bg-zinc-900/80 p-8 text-center shadow-xl">
         <p className="mb-2 text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">
-          Lighthouse Ops
+          FAROS
         </p>
         {/* Loading State */}
         {status === 'verifying' && (


### PR DESCRIPTION
## Summary
- replace mixed "Lighthouse Ops" labels with consistent FAROS branding across auth and verification surfaces
- standardize small branding text in login, register, forgot/reset password, and verify email pages
- align login footer identity text with FAROS branding

## Test plan
- [x] Run `make frontend-verify`
- [x] Confirm branding labels are consistent across auth and verification screens
- [x] Confirm no auth flow behavior changes

Closes #21