### PR TITLE
Task #20: fix pagination refresh after task deletions

### DIFF
--- a/frontend/src/components/Tasks/TaskDashboard.jsx
+++ b/frontend/src/components/Tasks/TaskDashboard.jsx
@@ -153,8 +153,17 @@ function TaskDashboard({ onLogout }) {
   const deleteTask = async (taskId) => {
     try {
       await taskService.deleteTask(taskId);
-      setTasks(tasks.filter((t) => t.id !== taskId));
+      const remainingTasks = tasks.filter((t) => t.id !== taskId);
+      setTasks(remainingTasks);
       fetchStats();
+
+      // Re-fetch list after deletion so pagination stays accurate without manual reload.
+      if (remainingTasks.length === 0 && page > 1) {
+        setPage((prev) => Math.max(1, prev - 1));
+      } else {
+        await fetchTasks();
+      }
+
       toast.success('Task deleted');
     } catch {
       toast.error('Failed to delete task');


### PR DESCRIPTION
## Summary
- fix deletion flow so paginated task lists re-sync immediately with server state
- refresh task data after each successful delete to prevent stale empty first pages
- when deleting the last task on a non-first page, step back one page automatically

## Test plan
- [x] Run `make frontend-verify`
- [x] Reproduce case: 2 pages of tasks, delete all tasks on page 1, verify remaining tasks appear without manual reload
- [x] Verify deleting final item on page > 1 navigates back to previous page

Closes #20