### PR TITLE
Task #22: add collaboration discoverability coachmark

### DIFF
--- a/frontend/docs/PATTERNS.md
+++ b/frontend/docs/PATTERNS.md
@@ -128,6 +128,23 @@ const canEdit = isOwner || (task.my_permission === 'edit');
 
 ---
 
+## First-Use Feature Hints
+
+When a key feature is not obvious from the default view, use a lightweight one-time hint in the local UI layer:
+
+```javascript
+const DISMISSED_KEY = 'faros:feature-hint-dismissed';
+const [showHint, setShowHint] = useState(false);
+```
+
+- Show hints only when the user has enough context (for example, existing tasks in personal view).
+- Persist dismissal in `localStorage` so the hint is not noisy.
+- Keep hints non-blocking and dismissible (`Got it` action).
+
+**Convention:** Prefer single-purpose in-context hints over full tours for discoverability polish.
+
+---
+
 ## Optimistic Updates
 
 For fast-feeling interactions, update local state before the API confirms:

--- a/frontend/src/components/Tasks/TaskDashboard.jsx
+++ b/frontend/src/components/Tasks/TaskDashboard.jsx
@@ -1,4 +1,4 @@
-import { Activity, BarChart3, Filter, FolderOpen, Plus, Share2, X } from 'lucide-react';
+import { Activity, BarChart3, Filter, FolderOpen, Plus, Share2, Users, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { useTasks } from '../../hooks/useTasks';
@@ -12,12 +12,21 @@ import SettingsModal from '../Settings/SettingsModal';
 import TaskForm from './TaskForm';
 import TaskList from './TaskList';
 
+const SHARE_TIP_DISMISSED_KEY = 'faros:share-tip-dismissed';
+
 function TaskDashboard({ onLogout }) {
   const [user, setUser] = useState(null);
   const [avatarTimestamp, setAvatarTimestamp] = useState(() => Date.now());
   const [showSettings, setShowSettings] = useState(false);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
+  const [shareTipDismissed, setShareTipDismissed] = useState(() => {
+    try {
+      return window.localStorage.getItem(SHARE_TIP_DISMISSED_KEY) === 'true';
+    } catch {
+      return false;
+    }
+  });
   const [showStatsMenu, setShowStatsMenu] = useState(false);
   const statsMenuRef = useRef(null);
 
@@ -179,6 +188,17 @@ function TaskDashboard({ onLogout }) {
     { label: 'Active', value: stats.incomplete || 0, tone: 'text-zinc-100' },
     { label: 'Late', value: stats.overdue || 0, tone: 'text-red-300' },
   ];
+  const showShareTip =
+    view === 'personal' && Boolean(user) && tasks.length > 0 && !shareTipDismissed;
+
+  const dismissShareTip = () => {
+    try {
+      window.localStorage.setItem(SHARE_TIP_DISMISSED_KEY, 'true');
+    } catch {
+      // If storage is unavailable, just hide for this session.
+    }
+    setShareTipDismissed(true);
+  };
 
   return (
     <div className="space-y-4">
@@ -393,6 +413,30 @@ function TaskDashboard({ onLogout }) {
                     Reset
                   </button>
                 </div>
+              </div>
+            </div>
+          )}
+
+          {showShareTip && (
+            <div className="mb-4 rounded-lg border border-emerald-500/30 bg-emerald-950/20 p-3">
+              <div className="flex items-start gap-3">
+                <Users size={16} className="mt-0.5 shrink-0 text-emerald-400" />
+                <div className="min-w-0 flex-1">
+                  <p className="text-xs font-bold uppercase tracking-wider text-emerald-300">
+                    Collaboration Tip
+                  </p>
+                  <p className="mt-1 text-sm text-zinc-300">
+                    Use the share icon on a task card to invite collaborators and
+                    choose their permissions.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={dismissShareTip}
+                  className="text-xs font-semibold text-emerald-300 transition-colors hover:text-emerald-200"
+                >
+                  Got it
+                </button>
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
- add a dismissible one-time collaboration tip in personal dashboard view to surface sharing functionality
- gate the hint to relevant context (personal view with existing tasks)
- persist dismissal via local storage so the tip is informative but non-noisy
- document the first-use feature hint convention in frontend patterns docs

## Test plan
- [x] Run `make frontend-verify`
- [x] Confirm tip appears in personal view when tasks exist
- [x] Confirm clicking `Got it` dismisses the tip and keeps it hidden on reload
- [x] Confirm tip does not appear in shared/activity views

Closes #22