### PR TITLE
Task #25: keyboard and modal accessibility hardening

### DIFF
--- a/frontend/docs/PATTERNS.md
+++ b/frontend/docs/PATTERNS.md
@@ -223,6 +223,19 @@ const handleSubmit = async () => {
 
 ---
 
+## Accessibility Baselines
+
+For interactive controls and dialogs, use keyboard-safe defaults:
+
+- Icon-only buttons should include `aria-label` (and `title` when helpful).
+- Dialog shells should expose `role="dialog"` and `aria-modal="true"`.
+- Escape key should close dismissible modals.
+- Interactive toggles should be real `<button>` elements, not clickable `<span>`/`<div>`.
+
+**Convention:** A11y polish is part of the component implementation, not a follow-up cleanup.
+
+---
+
 ## Backend Warmup
 
 The landing page pings `/health` on mount to wake up the Render free-tier backend:

--- a/frontend/src/components/Auth/LoginForm.jsx
+++ b/frontend/src/components/Auth/LoginForm.jsx
@@ -77,6 +77,8 @@ function LoginForm({
                 className={`absolute right-3 top-1/2 -translate-y-1/2 text-zinc-500 hover:text-zinc-300 transition-colors ${
                   isLoggingIn ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
                 }`}
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+                title={showPassword ? 'Hide password' : 'Show password'}
               >
                 {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
               </button>

--- a/frontend/src/components/Auth/PasswordResetForm.jsx
+++ b/frontend/src/components/Auth/PasswordResetForm.jsx
@@ -68,7 +68,16 @@ function PasswordResetForm({ token, onSwitchToLogin }) {
           type="button"
           onClick={() => toggleVisibility(visibilityKey)}
           className="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-500 hover:text-zinc-300 transition-colors cursor-pointer"
-          tabIndex="-1"
+          aria-label={
+            showPasswords[visibilityKey]
+              ? `Hide ${label.toLowerCase()}`
+              : `Show ${label.toLowerCase()}`
+          }
+          title={
+            showPasswords[visibilityKey]
+              ? `Hide ${label.toLowerCase()}`
+              : `Show ${label.toLowerCase()}`
+          }
         >
           {showPasswords[visibilityKey] ? (
             <EyeOff size={20} />

--- a/frontend/src/components/Auth/RegisterForm.jsx
+++ b/frontend/src/components/Auth/RegisterForm.jsx
@@ -101,6 +101,8 @@ function RegisterForm({ onRegister, isRegistering, onSwitchToLogin }) {
                 className={`absolute right-3 top-1/2 -translate-y-1/2 text-zinc-500 hover:text-zinc-300 transition-colors ${
                   isRegistering ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
                 }`}
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+                title={showPassword ? 'Hide password' : 'Show password'}
               >
                 {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
               </button>
@@ -128,6 +130,12 @@ function RegisterForm({ onRegister, isRegistering, onSwitchToLogin }) {
                 className={`absolute right-3 top-1/2 -translate-y-1/2 text-zinc-500 hover:text-zinc-300 transition-colors ${
                   isRegistering ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
                 }`}
+                aria-label={
+                  showConfirm ? 'Hide confirm password' : 'Show confirm password'
+                }
+                title={
+                  showConfirm ? 'Hide confirm password' : 'Show confirm password'
+                }
               >
                 {showConfirm ? <EyeOff size={18} /> : <Eye size={18} />}
               </button>

--- a/frontend/src/components/Settings/SecuritySection.jsx
+++ b/frontend/src/components/Settings/SecuritySection.jsx
@@ -82,7 +82,16 @@ function SecuritySection() {
           type="button"
           onClick={() => toggleVisibility(visibilityKey)}
           className="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-500 hover:text-zinc-300 transition-colors cursor-pointer"
-          tabIndex="-1"
+          aria-label={
+            showPasswords[visibilityKey]
+              ? `Hide ${label.toLowerCase()}`
+              : `Show ${label.toLowerCase()}`
+          }
+          title={
+            showPasswords[visibilityKey]
+              ? `Hide ${label.toLowerCase()}`
+              : `Show ${label.toLowerCase()}`
+          }
         >
           {showPasswords[visibilityKey] ? (
             <EyeOff size={18} />

--- a/frontend/src/components/Settings/SettingsModal.jsx
+++ b/frontend/src/components/Settings/SettingsModal.jsx
@@ -1,5 +1,5 @@
 import { Bell, Shield, User, X } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { THEME } from '../../styles/theme';
 import NotificationsSection from './NotificationSection';
 import ProfileSection from './ProfileSection';
@@ -17,16 +17,28 @@ function SettingsModal({ onClose, user, onUserUpdate, avatarUrl }) {
     { id: 'security', label: 'Security', icon: Shield },
   ];
 
+  useEffect(() => {
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [onClose]);
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4 backdrop-blur-sm animate-in fade-in duration-200" onClick={onClose}>
       <div
         className="relative flex h-[85vh] w-full max-w-4xl flex-col overflow-hidden rounded-2xl border border-zinc-800 bg-zinc-950 shadow-2xl md:h-150 md:flex-row"
         onClick={handleContentClick}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Settings"
       >
         {/* CLOSE BUTTON */}
         <button
           onClick={onClose}
           className={`${THEME.button.ghost} absolute right-4 top-4 z-20 bg-zinc-900/50 hover:bg-zinc-800`}
+          aria-label="Close settings"
         >
           <X size={20} />
         </button>
@@ -47,6 +59,7 @@ function SettingsModal({ onClose, user, onUserUpdate, avatarUrl }) {
                     ? 'border border-emerald-500/30 bg-emerald-500/15 text-emerald-100'
                     : 'text-zinc-400 hover:bg-zinc-800/50 hover:text-zinc-200'
                 }`}
+                aria-label={`Open ${tab.label} settings`}
               >
                 <tab.icon size={18} />
                 {tab.label}

--- a/frontend/src/components/Sharing/ShareModal.jsx
+++ b/frontend/src/components/Sharing/ShareModal.jsx
@@ -11,6 +11,14 @@ function ShareModal({ taskId, onClose, onCountChange }) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [onClose]);
+
+  useEffect(() => {
     if (!loading && onCountChange) {
       onCountChange(shares.length);
     }
@@ -94,6 +102,9 @@ function ShareModal({ taskId, onClose, onCountChange }) {
       <div
         className="w-full max-w-md overflow-hidden rounded-xl border border-zinc-800 bg-zinc-900/95 shadow-2xl"
         onClick={handleModalClick}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Share task"
       >
         <div className="flex items-center justify-between border-b border-zinc-800 p-4">
           <div className="flex items-center gap-2">
@@ -105,7 +116,11 @@ function ShareModal({ taskId, onClose, onCountChange }) {
               </p>
             </div>
           </div>
-          <button onClick={onClose} className={THEME.button.ghost}>
+          <button
+            onClick={onClose}
+            className={THEME.button.ghost}
+            aria-label="Close share dialog"
+          >
             <X size={20} />
           </button>
         </div>

--- a/frontend/src/components/Tasks/TaskCard.jsx
+++ b/frontend/src/components/Tasks/TaskCard.jsx
@@ -37,6 +37,7 @@ function TaskCard({
     onDelete(task.id);
     setShowDeleteConfirm(false);
   };
+  const toggleExpanded = () => setIsExpanded((prev) => !prev);
 
   const [editForm, setEditForm] = useState({
     title: task.title,
@@ -72,7 +73,7 @@ function TaskCard({
 
   const styles = {
     header:
-      'flex items-center justify-between gap-2.5 p-3 cursor-pointer transition-colors hover:bg-zinc-800/40',
+      'flex items-center justify-between gap-2.5 p-3 cursor-pointer transition-colors hover:bg-zinc-800/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60',
     checkbox:
       'w-5 h-5 accent-emerald-500 cursor-pointer rounded bg-zinc-900 border-zinc-600 focus:ring-emerald-500 shrink-0',
     detailsContainer:
@@ -153,6 +154,13 @@ function TaskCard({
       tags: task.tags ? task.tags.join(', ') : '',
     });
     setIsEditing(false);
+  };
+
+  const handleHeaderKeyDown = (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      toggleExpanded();
+    }
   };
 
   if (isEditing) {
@@ -245,7 +253,14 @@ function TaskCard({
   return (
     <>
       <div className={containerClass}>
-        <div className={styles.header} onClick={() => setIsExpanded(!isExpanded)}>
+        <div
+          className={styles.header}
+          onClick={toggleExpanded}
+          onKeyDown={handleHeaderKeyDown}
+          role="button"
+          tabIndex={0}
+          aria-expanded={isExpanded}
+        >
         <div className="flex min-w-0 flex-1 items-center gap-3">
           <input
             type="checkbox"
@@ -351,14 +366,18 @@ function TaskCard({
             </button>
           )}
 
-          <span
-            className="cursor-pointer ml-1 rounded-lg p-1.5 text-xs text-zinc-600 transition-transform duration-200 hover:bg-zinc-800/60"
-            style={{
-              transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              toggleExpanded();
             }}
+            aria-label={isExpanded ? 'Collapse task details' : 'Expand task details'}
+            className="ml-1 rounded-lg p-1.5 text-xs text-zinc-600 transition-transform duration-200 hover:bg-zinc-800/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60"
+            style={{ transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)' }}
           >
             <ChevronDown size={16} />
-          </span>
+          </button>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- improve keyboard support for task card expansion controls and add explicit expanded-state semantics
- add dialog accessibility defaults for settings/share modals (`role=dialog`, `aria-modal`, close labels, Escape close)
- add accessible labels/titles to password visibility toggles across auth/security forms
- document accessibility baseline conventions in frontend patterns

## Test plan
- [x] Run `make frontend-verify`
- [x] Verify task card can be expanded/collapsed via keyboard (Enter/Space)
- [x] Verify share/settings dialogs close via Escape and expose dialog semantics
- [x] Verify password visibility controls are keyboard focusable and labeled for screen readers

Closes #25