### PR TITLE
feat: improve activity feed readability and shared-task visibility

### DIFF
--- a/backend/routers/activity.py
+++ b/backend/routers/activity.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any, Optional, cast
 
 from fastapi import APIRouter, Depends, Query
-from sqlalchemy import desc
+from sqlalchemy import and_, desc, or_
 from sqlalchemy.orm import Session, joinedload
 
 import db_models
@@ -42,8 +42,28 @@ def get_my_activity(
     Returns activity logs ordered by most recent first
     """
 
+    # Subquery: task IDs shared with current user
+    shared_task_ids = (
+        db_session.query(db_models.TaskShare.task_id)
+        .filter(db_models.TaskShare.shared_with_user_id == current_user.id)
+    )
+
     query = db_session.query(db_models.ActivityLog).filter(
-        db_models.ActivityLog.user_id == current_user.id
+        or_(
+            # My own actions
+            db_models.ActivityLog.user_id == current_user.id,
+            # Shared task activity (exclude created/deleted — those are private)
+            and_(
+                db_models.ActivityLog.resource_type == "task",
+                db_models.ActivityLog.resource_id.in_(shared_task_ids),
+                db_models.ActivityLog.action.notin_(["created", "deleted"]),
+            ),
+            # Comment/file activity on tasks shared with me
+            and_(
+                db_models.ActivityLog.resource_type.in_(["comment", "file"]),
+                db_models.ActivityLog.details["task_id"].as_integer().in_(shared_task_ids),
+            ),
+        )
     )
 
     # Filters
@@ -142,35 +162,31 @@ def get_task_timeline(
 
     require_task_access(task, current_user, db_session, TaskPermission.VIEW)
 
-    # Get ALL activities that might be related
-    # We'll filter in Python - simpler and more readable
-    all_logs = (
+    # Query activity related to this task at the SQL level
+    logs = (
         db_session.query(db_models.ActivityLog)
         .options(joinedload(db_models.ActivityLog.user))
+        .filter(
+            or_(
+                # Direct task activity
+                and_(
+                    db_models.ActivityLog.resource_type == "task",
+                    db_models.ActivityLog.resource_id == task_id,
+                ),
+                # Comment/file activity referencing this task
+                and_(
+                    db_models.ActivityLog.resource_type.in_(["comment", "file"]),
+                    db_models.ActivityLog.details["task_id"].as_integer() == task_id,
+                ),
+            )
+        )
         .order_by(db_models.ActivityLog.created_at)
         .all()
     )
 
-    # Filter for this task in Python
-    task_logs = []
-    for log in all_logs:
-        # Check if this activity is related to our task
-        is_related = False
-
-        # Direct task activity
-        if log.resource_type == "task" and log.resource_id == task_id:  # type: ignore
-            is_related = True
-
-        # Comment/file activity (check details.task_id)
-        elif log.details and log.details.get("task_id") == task_id:  # type: ignore
-            is_related = True
-
-        if is_related:
-            task_logs.append(log)
-
     # Convert to response model
     results: list[ActivityLogResponse] = []
-    for log in task_logs:
+    for log in logs:
         log_obj = cast(Any, log)
         results.append(
             ActivityLogResponse(

--- a/backend/routers/sharing.py
+++ b/backend/routers/sharing.py
@@ -151,7 +151,7 @@ def share_task(
     activity_service.log_task_shared(
         db_session=db_session,
         user_id=current_user.id,  # type: ignore
-        task_id=task_id,
+        task=task,
         shared_with_user=shared_with_user,
         permission=share_data.permission,
     )
@@ -286,7 +286,7 @@ def unshare_task(
     activity_service.log_task_unshared(
         db_session=db_session,
         user_id=current_user.id,  # type: ignore
-        task_id=task_id,
+        task=task,
         unshared_user=share.shared_with,
     )
 

--- a/backend/services/activity_service.py
+++ b/backend/services/activity_service.py
@@ -76,6 +76,7 @@ def log_task_updated(
         resource_type="task",
         resource_id=task.id,  # type: ignore
         details={
+            "task_title": task.title,
             "changed_fields": changed_fields,
             "old_values": old_values,
             "new_values": new_values,
@@ -106,7 +107,7 @@ def log_task_deleted(
 def log_task_shared(
     db_session: Session,
     user_id: int,
-    task_id: int,
+    task: db_models.Task,
     shared_with_user: db_models.User,
     permission: str,
 ) -> db_models.ActivityLog:
@@ -116,8 +117,9 @@ def log_task_shared(
         user_id=user_id,
         action="shared",
         resource_type="task",
-        resource_id=task_id,
+        resource_id=task.id,  # type: ignore
         details={
+            "task_title": task.title,
             "shared_with_user_id": shared_with_user.id,
             "shared_with_username": shared_with_user.username,
             "permission": permission,
@@ -126,7 +128,7 @@ def log_task_shared(
 
 
 def log_task_unshared(
-    db_session: Session, user_id: int, task_id: int, unshared_user: db_models.User
+    db_session: Session, user_id: int, task: db_models.Task, unshared_user: db_models.User
 ) -> db_models.ActivityLog:
     """Log task unsharing."""
     return log_activity(
@@ -134,8 +136,9 @@ def log_task_unshared(
         user_id=user_id,
         action="unshared",
         resource_type="task",
-        resource_id=task_id,
+        resource_id=task.id,  # type: ignore
         details={
+            "task_title": task.title,
             "unshared_user_id": unshared_user.id,
             "unshared_username": unshared_user.username,
         },
@@ -155,7 +158,11 @@ def log_comment_created(
         action="created",
         resource_type="comment",
         resource_id=comment.id,  # type: ignore
-        details={"task_id": comment.task_id, "content_preview": comment.content[:100]},
+        details={
+            "task_id": comment.task_id,
+            "task_title": comment.task.title if comment.task else None,
+            "content_preview": comment.content[:100],
+        },
     )
 
 
@@ -175,6 +182,7 @@ def log_comment_updated(
         resource_id=comment.id,  # type: ignore
         details={
             "task_id": comment.task_id,
+            "task_title": comment.task.title if comment.task else None,
             "old_content": old_content[:100],
             "new_content": new_content[:100],
         },
@@ -191,7 +199,11 @@ def log_comment_deleted(
         action="deleted",
         resource_type="comment",
         resource_id=comment.id,  # type: ignore
-        details={"task_id": comment.task_id, "content": comment.content[:100]},
+        details={
+            "task_id": comment.task_id,
+            "task_title": comment.task.title if comment.task else None,
+            "content": comment.content[:100],
+        },
     )
 
 

--- a/backend/tests/test_activity.py
+++ b/backend/tests/test_activity.py
@@ -337,3 +337,126 @@ def test_activity_stats(authenticated_client):
     assert stats["by_action"]["updated"] == 1
     assert stats["by_action"]["deleted"] == 1
     assert stats["by_resource"]["task"] == 4
+
+
+def test_shared_task_activity_visible_to_collaborator(client, create_user_and_token):
+    """Test that collaborators see activity on tasks shared with them"""
+    alice_token = create_user_and_token("alice", "alice@test.com", "pass1234")
+    bob_token = create_user_and_token("bob", "bob@test.com", "pass1234")
+
+    # Alice creates a task
+    create_response = client.post(
+        "/tasks",
+        json={"title": "Shared project", "priority": "high"},
+        headers={"Authorization": f"Bearer {alice_token}"},
+    )
+    task_id = create_response.json()["id"]
+
+    # Alice shares with Bob
+    client.post(
+        f"/tasks/{task_id}/share",
+        json={"shared_with_username": "bob", "permission": "edit"},
+        headers={"Authorization": f"Bearer {alice_token}"},
+    )
+
+    # Alice updates the task
+    client.patch(
+        f"/tasks/{task_id}",
+        json={"title": "Updated project"},
+        headers={"Authorization": f"Bearer {alice_token}"},
+    )
+
+    # Bob should see Alice's activity on the shared task
+    bob_activity = client.get(
+        "/activity", headers={"Authorization": f"Bearer {bob_token}"}
+    )
+    bob_logs = bob_activity.json()
+
+    # Bob should see Alice's create, share, and update actions on the shared task
+    alice_logs = [log for log in bob_logs if log["username"] == "alice"]
+    assert len(alice_logs) >= 2  # At least create + update (share may also appear)
+
+    # Verify the actions are on the correct task
+    for log in alice_logs:
+        if log["resource_type"] == "task":
+            assert log["resource_id"] == task_id
+
+
+def test_unshared_task_activity_not_visible(client, create_user_and_token):
+    """Test that activity on unshared tasks remains invisible"""
+    alice_token = create_user_and_token("alice", "alice@test.com", "pass1234")
+    bob_token = create_user_and_token("bob", "bob@test.com", "pass1234")
+
+    # Alice creates a private task (NOT shared)
+    client.post(
+        "/tasks",
+        json={"title": "Alice private task", "priority": "low"},
+        headers={"Authorization": f"Bearer {alice_token}"},
+    )
+
+    # Alice creates a shared task
+    shared_response = client.post(
+        "/tasks",
+        json={"title": "Shared task", "priority": "high"},
+        headers={"Authorization": f"Bearer {alice_token}"},
+    )
+    shared_task_id = shared_response.json()["id"]
+
+    # Share only the second task
+    client.post(
+        f"/tasks/{shared_task_id}/share",
+        json={"shared_with_username": "bob", "permission": "view"},
+        headers={"Authorization": f"Bearer {alice_token}"},
+    )
+
+    # Bob's feed should only include activity on the shared task, not the private one
+    bob_activity = client.get(
+        "/activity", headers={"Authorization": f"Bearer {bob_token}"}
+    )
+    bob_logs = bob_activity.json()
+
+    alice_task_logs = [
+        log for log in bob_logs
+        if log["username"] == "alice" and log["resource_type"] == "task"
+    ]
+    for log in alice_task_logs:
+        assert log["resource_id"] == shared_task_id
+
+
+def test_shared_task_comment_activity_visible(client, create_user_and_token):
+    """Test that comment activity on shared tasks is visible to collaborators"""
+    alice_token = create_user_and_token("alice", "alice@test.com", "pass1234")
+    bob_token = create_user_and_token("bob", "bob@test.com", "pass1234")
+
+    # Alice creates and shares a task
+    create_response = client.post(
+        "/tasks",
+        json={"title": "Commented task", "priority": "medium"},
+        headers={"Authorization": f"Bearer {alice_token}"},
+    )
+    task_id = create_response.json()["id"]
+
+    client.post(
+        f"/tasks/{task_id}/share",
+        json={"shared_with_username": "bob", "permission": "edit"},
+        headers={"Authorization": f"Bearer {alice_token}"},
+    )
+
+    # Alice adds a comment
+    client.post(
+        f"/tasks/{task_id}/comments",
+        json={"content": "Hey Bob, check this out"},
+        headers={"Authorization": f"Bearer {alice_token}"},
+    )
+
+    # Bob should see Alice's comment activity
+    bob_activity = client.get(
+        "/activity?resource_type=comment",
+        headers={"Authorization": f"Bearer {bob_token}"},
+    )
+    bob_logs = bob_activity.json()
+
+    alice_comment_logs = [log for log in bob_logs if log["username"] == "alice"]
+    assert len(alice_comment_logs) == 1
+    assert alice_comment_logs[0]["action"] == "created"
+    assert alice_comment_logs[0]["resource_type"] == "comment"

--- a/frontend/src/components/Activity/ActivityFeed.jsx
+++ b/frontend/src/components/Activity/ActivityFeed.jsx
@@ -1,0 +1,111 @@
+import { Activity, Loader2 } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useActivityLog } from '../../hooks/useActivityLog';
+import { THEME } from '../../styles/theme';
+import ActivityItem from './ActivityItem';
+
+const RESOURCE_FILTERS = [
+  { key: null, label: 'All' },
+  { key: 'task', label: 'Tasks' },
+  { key: 'comment', label: 'Comments' },
+  { key: 'file', label: 'Files' },
+];
+
+function ActivityFeed({ initialFilter, initialPage, onStateChange }) {
+  const [resourceType, setResourceType] = useState(initialFilter || null);
+  const [page, setPage] = useState(initialPage || 1);
+
+  const { activities, loading, hasMore, fetchActivities } = useActivityLog(
+    resourceType,
+    page
+  );
+
+  useEffect(() => {
+    fetchActivities();
+  }, [fetchActivities]);
+
+  useEffect(() => {
+    onStateChange?.({ resourceType, page });
+  }, [resourceType, page, onStateChange]);
+
+  const handleFilterChange = (key) => {
+    setResourceType(key);
+    setPage(1);
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      {/* Header */}
+      <div className="mb-6 p-6 bg-zinc-900/30 border border-zinc-800 rounded-xl text-center">
+        <Activity className="w-10 h-10 text-blue-500 mx-auto mb-3 opacity-80" />
+        <h2 className="text-xl font-bold text-white">Activity Log</h2>
+      </div>
+
+      {/* Filter chips */}
+      <div className="mb-4 flex items-center gap-2">
+        {RESOURCE_FILTERS.map((f) => (
+          <button
+            key={f.label}
+            onClick={() => handleFilterChange(f.key)}
+            className={`px-3 py-1 text-xs font-bold uppercase tracking-wider rounded-full border transition-all cursor-pointer ${
+              resourceType === f.key
+                ? 'bg-emerald-600/20 border-emerald-500/50 text-emerald-400'
+                : 'bg-zinc-900/50 border-zinc-700 text-zinc-400 hover:border-zinc-500 hover:text-zinc-300'
+            }`}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Loading */}
+      {loading && (
+        <div className="flex justify-center py-12">
+          <Loader2 className="w-6 h-6 text-emerald-500 animate-spin" />
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!loading && activities.length === 0 && (
+        <div className="text-center py-12">
+          <Activity className="w-8 h-8 text-zinc-600 mx-auto mb-2" />
+          <p className="text-zinc-500 text-sm">No activity yet</p>
+        </div>
+      )}
+
+      {/* Activity list */}
+      {!loading && activities.length > 0 && (
+        <div className="space-y-1 bg-zinc-900/30 border border-zinc-800 rounded-xl p-4">
+          {activities.map((activity) => (
+            <ActivityItem key={activity.id} activity={activity} />
+          ))}
+        </div>
+      )}
+
+      {/* Pagination */}
+      {!loading && (page > 1 || hasMore) && (
+        <div className="mt-6 flex items-center justify-center gap-4 text-zinc-400">
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page === 1}
+            className={THEME.button.secondary}
+          >
+            Previous
+          </button>
+          <span>
+            Page <span className="font-semibold text-white">{page}</span>
+          </span>
+          <button
+            onClick={() => setPage((p) => p + 1)}
+            disabled={!hasMore}
+            className={THEME.button.secondary}
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ActivityFeed;

--- a/frontend/src/components/Activity/ActivityItem.jsx
+++ b/frontend/src/components/Activity/ActivityItem.jsx
@@ -1,17 +1,53 @@
-import { ChevronDown } from 'lucide-react';
+import {
+  ChevronDown,
+  Circle,
+  CirclePlus,
+  MessageSquare,
+  Pencil,
+  Trash2,
+  Upload,
+  UserMinus,
+  UserPlus,
+} from 'lucide-react';
 import { useState } from 'react';
 import {
+  PRIORITY_CONFIG,
   formatActivityDescription,
   formatRelativeTime,
   getActivityIcon,
 } from '../../utils/activityHelpers';
 
+const SEGMENT_STYLES = {
+  user: 'text-zinc-100 font-medium',
+  task: 'text-emerald-400/70',
+  field: 'text-blue-400/70',
+  comment: 'text-zinc-500 italic',
+  text: '',
+};
+
+const ICON_MAP = {
+  CirclePlus,
+  Pencil,
+  Trash2,
+  UserPlus,
+  UserMinus,
+  MessageSquare,
+  Upload,
+  Circle,
+};
+
 function ActivityItem({ activity }) {
   const [showDetails, setShowDetails] = useState(false);
 
-  const { icon } = getActivityIcon(activity.action, activity.resource_type);
-  const description = formatActivityDescription(activity);
+  const { icon: iconName, color } = getActivityIcon(activity.action, activity.resource_type);
+  const IconComponent = ICON_MAP[iconName] || Circle;
+  const segments = formatActivityDescription(activity);
   const timeAgo = formatRelativeTime(activity.created_at);
+
+  const priority =
+    activity.resource_type === 'task' && activity.details?.priority
+      ? PRIORITY_CONFIG[activity.details.priority]
+      : null;
 
   const hasExpandableDetails =
     activity.action === 'updated' &&
@@ -20,10 +56,25 @@ function ActivityItem({ activity }) {
 
   return (
     <div className="flex gap-3">
-      <div className="text-lg shrink-0">{icon}</div>
+      <div className="shrink-0 pt-0.5">
+        <IconComponent size={16} className={color} />
+      </div>
 
       <div className="flex-1 min-w-0">
-        <p className="text-sm text-zinc-300">{description}</p>
+        <p className="text-sm text-zinc-300">
+          {segments.map((s, i) => (
+            <span key={i} className={SEGMENT_STYLES[s.type] || ''}>
+              {s.text}
+            </span>
+          ))}
+          {priority && (
+            <span
+              className={`ml-1.5 inline-block align-middle px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider rounded border shrink-0 ${priority.class}`}
+            >
+              {priority.label}
+            </span>
+          )}
+        </p>
         <div className="flex items-center gap-2 mt-0.5">
           <p className="text-xs text-zinc-600">{timeAgo}</p>
           {hasExpandableDetails && (

--- a/frontend/src/components/Tasks/TaskDashboard.jsx
+++ b/frontend/src/components/Tasks/TaskDashboard.jsx
@@ -1,12 +1,12 @@
 import { Activity, BarChart3, Filter, FolderOpen, Plus, Share2, Users, X } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { useTasks } from '../../hooks/useTasks';
 import { taskService } from '../../services/taskService';
 import { userService } from '../../services/userService'; // Import userService
 import { THEME } from '../../styles/theme';
 import { buildApiUrl } from '../../config/env';
-import ActivityTimeline from '../Activity/ActivityTimeline';
+import ActivityFeed from '../Activity/ActivityFeed';
 import UserMenu from '../Common/UserMenu';
 import SettingsModal from '../Settings/SettingsModal';
 import TaskForm from './TaskForm';
@@ -16,6 +16,7 @@ const SHARE_TIP_DISMISSED_KEY = 'faros:share-tip-dismissed';
 const VALID_VIEWS = new Set(['personal', 'shared', 'activity']);
 const VALID_PRIORITIES = new Set(['high', 'medium', 'low']);
 const VALID_STATUSES = new Set(['pending', 'completed']);
+const VALID_RESOURCE_TYPES = new Set(['task', 'comment', 'file']);
 
 const getInitialDashboardState = () => {
   const defaults = {
@@ -33,6 +34,8 @@ const getInitialDashboardState = () => {
   const rawPage = params.get('page');
   const parsedPage = Number.parseInt(rawPage || '1', 10);
 
+  const rawType = params.get('type');
+
   return {
     view: VALID_VIEWS.has(rawView) ? rawView : defaults.view,
     page: Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1,
@@ -41,6 +44,8 @@ const getInitialDashboardState = () => {
       priority: VALID_PRIORITIES.has(rawPriority) ? rawPriority : '',
       status: VALID_STATUSES.has(rawStatus) ? rawStatus : '',
     },
+    activityFilter: VALID_RESOURCE_TYPES.has(rawType) ? rawType : null,
+    activityPage: Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1,
   };
 };
 
@@ -63,7 +68,14 @@ function TaskDashboard({ onLogout }) {
   const hasHydratedQueryStateRef = useRef(false);
   const previousQueryRef = useRef(initialDashboardState);
   const pendingViewRef = useRef(null);
+  const activityStateRef = useRef({ resourceType: initialDashboardState.activityFilter, page: initialDashboardState.activityPage });
+  const [activityUrlTick, setActivityUrlTick] = useState(0);
   const [isViewSwitching, setIsViewSwitching] = useState(false);
+
+  const handleActivityStateChange = useCallback(({ resourceType, page: actPage }) => {
+    activityStateRef.current = { resourceType, page: actPage };
+    setActivityUrlTick((t) => t + 1);
+  }, []);
 
   // View State
   const [page, setPage] = useState(initialDashboardState.page);
@@ -162,7 +174,11 @@ function TaskDashboard({ onLogout }) {
   useEffect(() => {
     const params = new URLSearchParams();
 
-    if (view !== 'personal') {
+    if (view === 'activity') {
+      params.set('view', view);
+      if (activityStateRef.current.resourceType) params.set('type', activityStateRef.current.resourceType);
+      if (activityStateRef.current.page > 1) params.set('page', String(activityStateRef.current.page));
+    } else if (view !== 'personal') {
       params.set('view', view);
     } else {
       const search = filters.search.trim();
@@ -179,7 +195,7 @@ function TaskDashboard({ onLogout }) {
     if (nextUrl !== currentUrl) {
       window.history.replaceState({}, document.title, nextUrl);
     }
-  }, [view, filters.search, filters.priority, filters.status, page]);
+  }, [view, filters.search, filters.priority, filters.status, page, activityUrlTick]);
 
   const addTask = async () => {
     if (!formData.title.trim()) return;
@@ -534,16 +550,13 @@ function TaskDashboard({ onLogout }) {
         </div>
       )}
 
-      {/* View: Activity Header */}
+      {/* View: Activity Feed */}
       {view === 'activity' && (
-        <div className="max-w-2xl mx-auto">
-          <div className="mb-6 p-6 bg-zinc-900/30 border border-zinc-800 rounded-xl text-center">
-            <Activity className="w-10 h-10 text-blue-500 mx-auto mb-3 opacity-80" />
-            <h2 className="text-xl font-bold text-white">Activity Log</h2>
-          </div>
-          {/* Note: This component might need props to function as a global feed */}
-          <ActivityTimeline />
-        </div>
+        <ActivityFeed
+          initialFilter={initialDashboardState.activityFilter}
+          initialPage={initialDashboardState.activityPage}
+          onStateChange={handleActivityStateChange}
+        />
       )}
 
       {/* Task List (Personal & Shared) */}

--- a/frontend/src/components/Tasks/TaskDashboard.jsx
+++ b/frontend/src/components/Tasks/TaskDashboard.jsx
@@ -68,13 +68,14 @@ function TaskDashboard({ onLogout }) {
   const hasHydratedQueryStateRef = useRef(false);
   const previousQueryRef = useRef(initialDashboardState);
   const pendingViewRef = useRef(null);
-  const activityStateRef = useRef({ resourceType: initialDashboardState.activityFilter, page: initialDashboardState.activityPage });
-  const [activityUrlTick, setActivityUrlTick] = useState(0);
+  const [activityState, setActivityState] = useState({
+    resourceType: initialDashboardState.activityFilter,
+    page: initialDashboardState.activityPage,
+  });
   const [isViewSwitching, setIsViewSwitching] = useState(false);
 
   const handleActivityStateChange = useCallback(({ resourceType, page: actPage }) => {
-    activityStateRef.current = { resourceType, page: actPage };
-    setActivityUrlTick((t) => t + 1);
+    setActivityState({ resourceType, page: actPage });
   }, []);
 
   // View State
@@ -176,8 +177,8 @@ function TaskDashboard({ onLogout }) {
 
     if (view === 'activity') {
       params.set('view', view);
-      if (activityStateRef.current.resourceType) params.set('type', activityStateRef.current.resourceType);
-      if (activityStateRef.current.page > 1) params.set('page', String(activityStateRef.current.page));
+      if (activityState.resourceType) params.set('type', activityState.resourceType);
+      if (activityState.page > 1) params.set('page', String(activityState.page));
     } else if (view !== 'personal') {
       params.set('view', view);
     } else {
@@ -195,7 +196,7 @@ function TaskDashboard({ onLogout }) {
     if (nextUrl !== currentUrl) {
       window.history.replaceState({}, document.title, nextUrl);
     }
-  }, [view, filters.search, filters.priority, filters.status, page, activityUrlTick]);
+  }, [view, filters.search, filters.priority, filters.status, page, activityState]);
 
   const addTask = async () => {
     if (!formData.title.trim()) return;
@@ -553,8 +554,8 @@ function TaskDashboard({ onLogout }) {
       {/* View: Activity Feed */}
       {view === 'activity' && (
         <ActivityFeed
-          initialFilter={initialDashboardState.activityFilter}
-          initialPage={initialDashboardState.activityPage}
+          initialFilter={activityState.resourceType}
+          initialPage={activityState.page}
           onStateChange={handleActivityStateChange}
         />
       )}

--- a/frontend/src/hooks/useActivityLog.js
+++ b/frontend/src/hooks/useActivityLog.js
@@ -1,0 +1,45 @@
+import { useCallback, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { taskService } from '../services/taskService';
+
+const ITEMS_PER_PAGE = 20;
+
+export function useActivityLog(resourceType, page) {
+  const [activities, setActivities] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+  const abortControllerRef = useRef(null);
+
+  const fetchActivities = useCallback(async () => {
+    setLoading(true);
+    if (abortControllerRef.current) abortControllerRef.current.abort();
+    const newController = new AbortController();
+    abortControllerRef.current = newController;
+
+    try {
+      const params = {
+        limit: ITEMS_PER_PAGE + 1,
+        offset: (page - 1) * ITEMS_PER_PAGE,
+        ...(resourceType && { resource_type: resourceType }),
+      };
+      const response = await taskService.getGlobalActivity(
+        params,
+        newController.signal
+      );
+      const items = response.data;
+      if (items.length > ITEMS_PER_PAGE) {
+        setActivities(items.slice(0, ITEMS_PER_PAGE));
+        setHasMore(true);
+      } else {
+        setActivities(items);
+        setHasMore(false);
+      }
+    } catch (err) {
+      if (err.name !== 'CanceledError') toast.error('Failed to load activity');
+    } finally {
+      if (abortControllerRef.current === newController) setLoading(false);
+    }
+  }, [resourceType, page]);
+
+  return { activities, loading, hasMore, fetchActivities };
+}

--- a/frontend/src/services/taskService.js
+++ b/frontend/src/services/taskService.js
@@ -38,5 +38,5 @@ export const taskService = {
 
   // Activity
   getTaskActivity: (taskId) => api.get(`/activity/tasks/${taskId}`),
-  getGlobalActivity: () => api.get('/activity'),
+  getGlobalActivity: (params, signal) => api.get('/activity', { params, signal }),
 };

--- a/frontend/src/utils/activityHelpers.js
+++ b/frontend/src/utils/activityHelpers.js
@@ -1,67 +1,144 @@
+export const PRIORITY_CONFIG = {
+  high: {
+    label: 'HIGH',
+    class: 'text-orange-400 bg-orange-950/30 border-orange-900/50',
+  },
+  medium: {
+    label: 'MED',
+    class: 'text-yellow-400 bg-yellow-950/30 border-yellow-900/50',
+  },
+  low: {
+    label: 'LOW',
+    class: 'text-emerald-400 bg-emerald-950/30 border-emerald-900/50',
+  },
+};
+
 export function getActivityIcon(action, resourceType) {
   if (resourceType === 'task') {
     switch (action) {
       case 'created':
-        return { icon: '🟢', color: 'text-emerald-400' };
+        return { icon: 'CirclePlus', color: 'text-emerald-400' };
       case 'updated':
-        return { icon: '✏️', color: 'text-blue-400' };
+        return { icon: 'Pencil', color: 'text-blue-400' };
       case 'deleted':
-        return { icon: '🗑️', color: 'text-red-400' };
+        return { icon: 'Trash2', color: 'text-red-400' };
       case 'shared':
-        return { icon: '🔵', color: 'text-purple-400' };
+        return { icon: 'UserPlus', color: 'text-purple-400' };
       case 'unshared':
-        return { icon: '⚫', color: 'text-zinc-600' };
+        return { icon: 'UserMinus', color: 'text-zinc-500' };
       default:
-        return { icon: '●', color: 'text-zinc-500' };
+        return { icon: 'Circle', color: 'text-zinc-500' };
     }
   }
 
   if (resourceType === 'comment') {
-    return { icon: '💬', color: 'text-amber-400' };
+    return { icon: 'MessageSquare', color: 'text-amber-400' };
   }
 
   if (resourceType === 'file') {
     return action === 'uploaded'
-      ? { icon: '📎', color: 'text-blue-400' }
-      : { icon: '🗑️', color: 'text-red-400' };
+      ? { icon: 'Upload', color: 'text-blue-400' }
+      : { icon: 'Trash2', color: 'text-red-400' };
   }
 
-  return { icon: '●', color: 'text-zinc-500' };
+  return { icon: 'Circle', color: 'text-zinc-500' };
+}
+
+// Segment types: 'user', 'task', 'text', 'field', 'comment'
+function seg(text, type = 'text') {
+  return { text, type };
 }
 
 export function formatActivityDescription(activity) {
   const { action, resource_type, details, username } = activity;
+  const user = seg(username, 'user');
 
   if (resource_type === 'task') {
+    const taskName = details?.task_title || details?.title;
     switch (action) {
       case 'created':
-        return `${username} created task`;
+        return taskName
+          ? [user, seg(' created task '), seg(taskName, 'task')]
+          : [user, seg(' created a task')];
       case 'updated':
         if (details?.changed_fields) {
-          return `${username} updated ${details.changed_fields.join(', ')}`;
+          const fields = seg(details.changed_fields.join(', '), 'field');
+          return taskName
+            ? [user, seg(' updated '), fields, seg(' on '), seg(taskName, 'task')]
+            : [user, seg(' updated '), fields];
         }
-        return `${username} updated task`;
+        return taskName
+          ? [user, seg(' updated task '), seg(taskName, 'task')]
+          : [user, seg(' updated a task')];
       case 'deleted':
-        return `${username} deleted task`;
+        return taskName
+          ? [user, seg(' deleted task '), seg(taskName, 'task')]
+          : [user, seg(' deleted a task')];
       case 'shared':
-        return `${username} shared with ${details?.shared_with_username} (${details?.permission})`;
+        return taskName
+          ? [
+              user,
+              seg(' shared '),
+              seg(taskName, 'task'),
+              seg(' with '),
+              seg(details?.shared_with_username, 'user'),
+              seg(` (${details?.permission})`),
+            ]
+          : [
+              user,
+              seg(' shared a task with '),
+              seg(details?.shared_with_username, 'user'),
+              seg(` (${details?.permission})`),
+            ];
       case 'unshared':
-        return `${username} removed ${details?.unshared_username}'s access`;
+        return taskName
+          ? [
+              user,
+              seg(' removed '),
+              seg(details?.unshared_username, 'user'),
+              seg("'s access on "),
+              seg(taskName, 'task'),
+            ]
+          : [
+              user,
+              seg(' removed '),
+              seg(details?.unshared_username, 'user'),
+              seg("'s access"),
+            ];
       default:
-        return `${username} ${action} task`;
+        return [user, seg(` ${action} task`)];
     }
   }
 
   if (resource_type === 'comment') {
+    const taskName = details?.task_title;
+    const preview = details?.content_preview;
     switch (action) {
       case 'created':
-        return `${username} added a comment`;
+        if (preview) {
+          return taskName
+            ? [
+                user,
+                seg(' commented on '),
+                seg(taskName, 'task'),
+                seg(': '),
+                seg(`"${preview}"`, 'comment'),
+              ]
+            : [user, seg(' commented: '), seg(`"${preview}"`, 'comment')];
+        }
+        return taskName
+          ? [user, seg(' added a comment on '), seg(taskName, 'task')]
+          : [user, seg(' added a comment')];
       case 'updated':
-        return `${username} edited a comment`;
+        return taskName
+          ? [user, seg(' edited a comment on '), seg(taskName, 'task')]
+          : [user, seg(' edited a comment')];
       case 'deleted':
-        return `${username} deleted a comment`;
+        return taskName
+          ? [user, seg(' deleted a comment on '), seg(taskName, 'task')]
+          : [user, seg(' deleted a comment')];
       default:
-        return `${username} ${action} comment`;
+        return [user, seg(` ${action} comment`)];
     }
   }
 
@@ -69,15 +146,15 @@ export function formatActivityDescription(activity) {
     const filename = details?.filename || 'a file';
     switch (action) {
       case 'uploaded':
-        return `${username} uploaded ${filename}`;
+        return [user, seg(` uploaded ${filename}`)];
       case 'deleted':
-        return `${username} deleted ${filename}`;
+        return [user, seg(` deleted ${filename}`)];
       default:
-        return `${username} ${action} file`;
+        return [user, seg(` ${action} file`)];
     }
   }
 
-  return `${username} ${action} ${resource_type}`;
+  return [user, seg(` ${action} ${resource_type}`)];
 }
 
 export function formatRelativeTime(timestamp) {


### PR DESCRIPTION
## Summary
- **Styled activity segments**: `formatActivityDescription` now returns typed segments (`user`, `task`, `field`, `comment`) rendered with distinct styles — brighter usernames, emerald task titles, blue changed fields, muted italic comment previews
- **Shared-task visibility**: collaborators see updates, shares, and comment/file activity on tasks shared with them (SQL-level filtering replaces Python-side filtering)
- **Dedicated ActivityFeed component**: extracted from TaskDashboard with resource-type filter chips, pagination, and URL query-state sync (`?view=activity&type=task&page=2`)
- **Richer detail payloads**: `task_title` now included in all activity types (updates, shares, unshares, comments) for consistent display
- **Lucide icons + priority badges**: replaced emoji icons with Lucide components and added inline priority badges

## Test plan
- [x] Backend tests pass (`test_shared_task_activity_visible_to_collaborator`, `test_unshared_task_activity_not_visible`, `test_shared_task_comment_activity_visible`)
- [x] Frontend lint and build pass
- [x] Manual verification: created fresh activity data and confirmed styled segments render correctly
- [x] Verify activity feed pagination works across filter changes
- [x] Verify shared-task activity appears in collaborator feeds